### PR TITLE
Overwrite ini generated by PIE with custom one

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -5,9 +5,15 @@ $(PHP_PECL_EXTENSION): $(RELAY_ARTIFACT)
 	echo "$(shell curl -fsL $(RELAY_DOWNLOAD_URL).sha256)  $(RELAY_TMPDIR)/$<" | shasum -a 256 --check
 	@tar -xf $(RELAY_TMPDIR)/$< --strip-components=1 -C $(RELAY_TMPDIR)
 	@LC_ALL=C $(SED) -iE "s/00000000-0000-0000-0000-000000000000/$(shell uuidgen)/" $(RELAY_TMPDIR)/$@.so
+	@cp $(RELAY_TMPDIR)/$@.ini $(phplibdir)/../
 	@cp $(RELAY_TMPDIR)/$@.so $(phplibdir)
 	@rm -fr $(RELAY_TMPDIR)
 
 $(RELAY_ARTIFACT):
 	curl -fsL $(RELAY_DOWNLOAD_URL) -o $(RELAY_TMPDIR)/$@
 
+ifdef RELAY_PRIORITY
+install: install-ini
+install-ini: $(phplibdir)/../$(PHP_PECL_EXTENSION).ini
+	@cp $< $(shell $(PHP_CONFIG) --ini-dir)/$(RELAY_PRIORITY)-$(PHP_PECL_EXTENSION).ini
+endif

--- a/config.m4
+++ b/config.m4
@@ -89,6 +89,12 @@ AC_DEFUN([RELAY_CHECK_PROGS], [
   ])dnl
 ])dnl
 
+dnl priority
+AC_CHECK_FILE([composer.json], [
+  RELAY_PRIORITY=$($EGREP priority composer.json | $SED 's/"priority"://' | cut -d , -f -1)
+])
+PHP_SUBST([RELAY_PRIORITY])
+
 PHP_NEW_EXTENSION([relay])
 RELAY_SET_DOWNLOAD_URL([0.9.1])
 RELAY_CHECK_PROGS([curl, shasum, tar, uuidgen])


### PR DESCRIPTION
```bash
root@0c79ba67b1e2:/pie# bin/pie install cachewerk/ext-relay:dev-feature/ini
You are running PHP 8.3.6
Target PHP installation: 8.3.6 nts, on Linux/OSX/etc x86_64 (from /usr/bin/php8.3)
Found package: cachewerk/ext-relay:dev-feature/ini which provides ext-relay
Extracted cachewerk/ext-relay:dev-feature/ini source to: /root/.pie/php8.3_a4ae3880c6d379dc165f2ab4092ba127/vendor/cachewerk/ext-relay
phpize complete.
Configure complete.
Build complete: /root/.pie/php8.3_a4ae3880c6d379dc165f2ab4092ba127/vendor/cachewerk/ext-relay/modules/relay.so
Install complete: /usr/lib/php/20230831/relay.so
✅ Extension is enabled and loaded in /usr/bin/php8.3
```
```bash
root@0c79ba67b1e2:/pie# ls -l `php-config --ini-dir`/* | grep relay
-rw-r--r-- 1 root root 2958 Jan  6 18:25 /etc/php/8.3/cli/conf.d/70-relay.ini
```
```bash
root@0c79ba67b1e2:/pie# cat /etc/php/8.3/cli/conf.d/70-relay.ini
; The path to the extension binary.
; Relative paths will look in `php-config --extension-dir`.
;
extension = relay.so

; Relay license key (via https://relay.so).
; Without a license key Relay will throttle to 16MB memory one hour after startup.
;
; relay.key =

; The environment Relay is running in.
; Supported values: `production`, `staging`, `testing`, `development`
;
; relay.environment = development

; How much memory Relay allocates on startup. This value can either be a
; number like 134217728 or a unit (e.g. 128M) like memory_limit.
; See: https://php.net/manual/faq.using.php#faq.using.shorthandbytes
;
; Relay will allocate at least 16M for overhead structures.
; Set to `0` to disable in-memory caching and use as client only.
;
; relay.maxmemory = 32M

; At what percentage of used memory should Relay start evicting keys.
;
; relay.maxmemory_pct = 95

; How Relay evicts keys. This has been designed to mirror Redis’
; options and we currently support `noeviction`, `lru`, and `random`.
; The default `noeviction` policy will proxy all uncached commands
; to Redis, once the in-memory cache is full.
;
; relay.eviction_policy = noeviction

; How many keys should we scan each time we process evictions.
;
; relay.eviction_sample_keys = 128

; Default to using a persistent connection when calling `connect()`.
;
; relay.default_pconnect = 1

; The number of databases Relay will create per in-memory cache.
; This setting should match the `databases` setting in your `redis.conf`.
;
; relay.databases = 16

; The maximum number of PHP workers that will have their own in-memory cache.
; While each PHP worker will have its own connection to Redis, not all
; workers need their own in-memory cache and can be read-only workers.
;
; This setting is per connection endpoint (distinct Redis connections),
; e.g. connecting to two separate instances will double the workers.
;
; relay.max_endpoint_dbs = 32

; The number of epoch readers allocated on startup.
;
; relay.initial_readers = 128

; How often (in microseconds) Relay should proactively check the
; connection for invalidation messages from Redis.
;
; relay.invalidation_poll_freq = 5

; Cluster configuration.
;
; relay.cluster.seeds = "moriarty[]=tcp://127.0.0.1:7000&moriarty[]=tcp://127.0.0.1:7001"
; relay.cluster.auth = "moriarty=Picard-Epsilon-7-9-3"
; relay.cluster.timeout = "moriarty=0.5"
; relay.cluster.read_timeout = "moriarty=1.0"

; Session handler configuration.
; Use in combination with `session.save_handler` and `session.save_path`.
;
; relay.session.locking_enabled = 0
; relay.session.lock_expire = 0
; relay.session.lock_retries = 0
; relay.session.lock_wait_time = 0
; relay.session.compression = none
; relay.session.compression_level = 0

; Logging configuration.
; Supported levels: `debug`, `verbose`, `notice`, `error`, `off`
;
; relay.loglevel = off

; The logging destination. Either `stderr` or an absolute path.
;
; relay.logfile = /tmp/relay.log
