### PR TITLE
Make igbinary and msgpack optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,11 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "ext-session": "*",
-        "ext-msgpack": "*",
-        "ext-igbinary": "*"
+        "ext-session": "*"
+    },
+    "suggest": {
+        "ext-igbinary": "To use the igbinary serializer (Relay\\Relay::SERIALIZER_IGBINARY)",
+        "ext-msgpack": "To use the msgpack serializer (Relay\\Relay::SERIALIZER_MSGPACK)"
     },
     "php-ext": {
         "extension-name": "relay",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "cachewerk/ext-relay",
-    "description": "The fastest Redis™ client for PHP. 100× faster cache reads, near-zero bandwidth, no code changes required.",
+    "description": "The fastest Redis client for PHP. 100× faster cache reads, near-zero bandwidth, no code changes required.",
     "type": "php-ext",
     "license": "MIT",
     "require": {
@@ -9,8 +9,8 @@
         "ext-session": "*"
     },
     "suggest": {
-        "ext-igbinary": "To use the igbinary serializer (Relay\\Relay::SERIALIZER_IGBINARY)",
-        "ext-msgpack": "To use the msgpack serializer (Relay\\Relay::SERIALIZER_MSGPACK)"
+        "ext-igbinary": "To use the igbinary serializer",
+        "ext-msgpack": "To use the MessagePack serializer"
     },
     "php-ext": {
         "extension-name": "relay",


### PR DESCRIPTION
`igbinary` and `msgpack` are now **optional** for Relay. As of the recent relay-core change, both serializers are compiled into Relay but **resolved at runtime** (bound via `dlsym` at module startup): if the extension is loaded the matching serializer is available, and if not, Relay still loads and works without it. `json` and `session` remain required.

Move `ext-igbinary` and `ext-msgpack` from `require` to a new `suggest` block in `composer.json`, so PIE/Composer no longer treat them as hard requirements. `php`, `ext-json` and `ext-session` stay in `require`.

Part of a cross-repo sweep updating references that still treated these extensions as hard requirements.